### PR TITLE
Initial Release of Terraform AWS Security Group Module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,37 +1,26 @@
-# Local .terraform directories
-**/.terraform/*
-
-# .tfstate files
+# Terraform files
 *.tfstate
 *.tfstate.*
-
-# Crash log files
 crash.log
-crash.*.log
-
-# Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
-# to change depending on the environment.
 *.tfvars
 *.tfvars.json
-
-# Ignore override files as they are usually used to override resources locally and so
-# are not checked in
 override.tf
 override.tf.json
 *_override.tf
 *_override.tf.json
 
-# Ignore transient lock info files created by terraform apply
-.terraform.tfstate.lock.info
+# Terraform directories
+.terraform/
+.terraform.lock.hcl
 
-# Include override files you do wish to add to version control using negated pattern
-# !example_override.tf
+# Local .env files
+.env
+.env.*
 
-# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
-# example: *tfplan*
+# IDE files
+.vscode/
+.idea/
 
-# Ignore CLI configuration files
-.terraformrc
-terraform.rc
+# OS generated files
+.DS_Store
+Thumbs.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+#### Change Log
+
+[1.0.0] - 2024-12-29
+
+##### Added
+- Initial release of the Terraform AWS Security Group module.
+- Create security groups with or without specified ingress and egress rules.
+- Add rules to an existing security group.
+- Support for tagging resources.
+- Example usage provided in README.
+- Default tags configuration.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+
+MIT License
+
+Copyright (c) 2024 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,184 @@
-# terraform-aws-security-group
-◉ 🚩Private Terraform Registry Module - Security Group with Rules
+![](https://img.shields.io/github/commit-activity/t/subhamay-bhattacharyya/terraform-aws-security-group)&nbsp;![](https://img.shields.io/github/last-commit/subhamay-bhattacharyya/terraform-aws-security-group)&nbsp;![](https://img.shields.io/github/release-date/subhamay-bhattacharyya/terraform-aws-security-group)&nbsp;![](https://img.shields.io/github/repo-size/subhamay-bhattacharyya/terraform-aws-security-group)&nbsp;![](https://img.shields.io/github/directory-file-count/subhamay-bhattacharyya/terraform-aws-security-group)&nbsp;[](https://img.shields.io/github/issues/subhamay-bhattacharyya/terraform-aws-security-group)&nbsp;![](https://img.shields.io/github/languages/top/subhamay-bhattacharyya/terraform-aws-security-group)&nbsp;![](https://img.shields.io/github/commit-activity/m/subhamay-bhattacharyya/terraform-aws-security-group)&nbsp;![](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/bsubhamay/889647c4be2d0f8fb1ef2fb965f2daba/raw/terraform-aws-security-group.json?)
+
+## Terraform AWS Security Group Module
+
+### Usage
+
+* Terraform module to create security groups.
+* Module source: app.terraform.io/subhamay-bhattacharyya/security-group/aws
+* Version: 1.0.0
+
+### Required Inputs:
+- `project-name`: The name of the project.
+- `vpc-id`: The ID of the VPC where the security group will be created.
+- `security_group_configuration`: A map defining the security group wilth associated rules.
+- `ci-build`: A string representing the CI build identifier.
+
+### Example Usage:
+
+```hcl
+module "security_group" {
+  source  = "app.terraform.io/subhamay-bhattacharyya/security-group/aws"
+  version = "1.0.0"
+
+  project-name                 = "your-project-name"
+  vpc-id                       = "your-vpc-id"
+  security-group-configuration = "your-security-group-configuration"
+  ci-build                     = "your-ci-build-string"
+}
+```
+
+### Security Group configuration
+
+##### Configure the security group with associated rules as a map type variable
+```hcl
+  security-group-configuration = {
+    name        = "ec2-sg"
+    description = "EC2 Security Group"
+    ingress = {
+      ssh = {
+        name        = "Allows SSH"
+        description = "Allows inbound SSH traffic on port 22 from anywhere."
+        from        = 22
+        to          = 22
+        protocol    = "tcp"
+        cidr-blocks = "0.0.0.0/0"
+      }
+      ssh = {
+        name             = "Allows SSH"
+        description      = "Allows inbound traffic from ec2 instance connect endpoints on port 22."
+        from             = 22
+        to               = 22
+        protocol         = "tcp"
+        referenced-sg-id = module.ecic_security_group.security-group-id
+    }
+    egress = {
+      https = {
+        name           = "Allows HTTPS"
+        description    = "Allows outbound traffic from ec2 instance security group to s3 prefix list."
+        from           = 443
+        to             = 443
+        protocol       = "tcp"
+        prefix-list-id = data.aws_ec2_managed_prefix_list.s3_vpce_prefix_list.id
+      }
+    }
+  }
+```
+
+##### Default tags
+
+Use local variables to configure the default tags.
+_The default resource tags are implemented using the CI/CD Pipeline. The following mao just refers to it._
+```hcl
+locals {
+  tags = {
+    Environment      = var.environment-name
+    ProjectName      = var.project-name
+    GitHubRepository = var.github-repo
+    GitHubRef        = var.github-ref
+    GitHubURL        = var.github-url
+    GitHubSHA        = var.github-sha
+  }
+}
+
+Use local variable to configure the security group configuration.
+
+locals {
+  vpc-endpoint-sg = {
+    name        = "vpc-endpoint"
+    description = "VPC Endpoint Security Group"
+    ingress = {
+      https = {
+        name        = "Allows HTTPS"
+        description = "Allows inbound traffic from the VPC on port 443."
+        from        = 443
+        to          = 443
+        protocol    = "tcp"
+        cidr-blocks = var.vpc-cidr
+      }
+    }
+    egress = {}
+  }
+
+  ec2-instance-sg = {
+    name        = "ec2-instance"
+    description = "EC2 Instance Security Group"
+    ingress     = {}
+    egress = {}
+  }
+
+  ec2-instance-connect-sg = {
+    name        = "ec2-instance-connect"
+    description = "EC2 Instance Connect Security Group"
+    ingress     = {}
+    egress      = {}
+  }
+
+  ec2-instance-sg-rules = {
+    security-group-id = module.ec2_security_group.security-group-id
+    ingress = {
+      ssh = {
+        name             = "Allows SSH"
+        description      = "Allows inbound traffic from ec2 instance connect endpoints on port 22."
+        from             = 22
+        to               = 22
+        protocol         = "tcp"
+        referenced-sg-id = module.ecic_security_group.security-group-id
+      }
+    }
+    egress = {
+      https = {
+        name             = "Allows HTTPS"
+        description      = "Allows outbound traffic to the endpoints on port 443."
+        from             = 443
+        to               = 443
+        protocol         = "tcp"
+        referenced-sg-id = module.vpce_security_group.security-group-id
+      }
+      https1 = {
+        name           = "Allows HTTPS"
+        description    = "Allows outbound traffic from ec2 instance security group to s3 prefix list."
+        from           = 443
+        to             = 443
+        protocol       = "tcp"
+        prefix-list-id = data.aws_ec2_managed_prefix_list.s3_vpce_prefix_list.id
+      }
+    }
+  }
+
+  ec2-instance-connect-sg-rules = {
+    security-group-id = module.ecic_security_group.security-group-id
+    ingress           = {}
+    egress = {
+      ssh = {
+        name             = "Allows SSH"
+        description      = "Allows outbound SSH traffic on port 22 to ec2 instance security group."
+        from             = 22
+        to               = 22
+        protocol         = "tcp"
+        referenced-sg-id = module.ec2_security_group.security-group-id
+      }
+    }
+}
+
+```
+#### Note
+
+
+## Inputs
+
+| Name                      | Description                                                                 | Type   | Default       | Required |
+|- |- |- |- |- |
+| project-name              | The name of the project                                                     | string | n/a           | yes      |
+| vpc-id                    | The VPC ID where the security group will be created                         | string | n/a           | yes      |
+| security-group-configuration | Configuration for the security group                                      | object | n/a           | yes      |
+| ci-build                  | A string representing the CI build identifier                               | string | ""            | yes      |
+
+## Outputs
+
+| Name                  | Description                                      |
+|- |- |
+| security-group-id     | The ID of the security group.                    |
+| security-group-name   | The name of the security group.                  |
+| security-group-arn    | The ARN of the security group.                   |
+| security-group-rules  | The security group rules (inbound and outbound). |

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,13 @@
+#### Version: 1.0.0
+Initial release of the Terraform AWS Security Group module.
+Version: 1.0.0
+Author: Subhamay Bhattacharyya
+Created: 25-Dec-2024
+Updated: 
+Description: This module creates and manages AWS Security Groups with specified ingress and egress rules using Terraform.
+
+## Features
+- Create security groups with specified ingress and egress rules
+- Support for tagging resources
+- Example usage provided in README
+- Default tags configuration

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,17 @@
+/*
+####################################################################################################
+# Terraform Security Group Module Data Block Configuration
+#
+# Description: This module creates a Security Group in AWS with the specified rules.
+#
+# Author: Subhamay Bhattacharyya
+# Created: 29-Dec-2024
+# Version: 1.0
+#
+####################################################################################################
+*/
+
+# AWS Region and Caller Identity
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,97 @@
+/*
+####################################################################################################
+# Terraform Security Group Module Configuration
+#
+# Description: This module creates a Security Group in AWS with the specified rules.
+#
+# Author: Subhamay Bhattacharyya
+# Created: 29-Dec-2024 
+# Version: 1.0
+#
+####################################################################################################
+*/
+
+
+
+# Creates an AWS Security Group based on the provided configuration.
+# 
+# Arguments:
+# - var.security-group-configuration.name: The name of the security group. If null, the resource is not created.
+# - var.project-name: The name of the project, used to prefix the security group name.
+# - var.security-group-configuration.description: The description of the security group.
+# - var.vpc-id: The ID of the VPC where the security group will be created.
+# - var.ci-build: The CI build identifier, used to suffix the security group name.
+# 
+# Tags:
+# - Name: The name tag for the security group, formatted as "${var.project-name}-${var.security-group-configuration.name}-sg${var.ci-build}".
+resource "aws_security_group" "security_group" {
+  count       = var.security-group-configuration.name != null ? 1 : 0
+  name        = "${var.project-name}-${var.security-group-configuration.name}-sg${var.ci-build}"
+  description = var.security-group-configuration.description
+  vpc_id      = var.vpc-id
+
+  tags = {
+    Name = "${var.project-name}-${var.security-group-configuration.name}-sg${var.ci-build}"
+  }
+}
+
+
+
+# Creates an ingress rule for a security group in AWS VPC.
+# 
+# Arguments:
+#   for_each: Iterates over the ingress rules defined in the variable `security-group-configuration["ingress"]`.
+#   security_group_id: The ID of the security group to which the ingress rule will be applied. If the security group name is provided, it uses the ID of the created security group, otherwise it uses the provided security group ID.
+#   cidr_ipv4: The CIDR blocks to allow access from. Defaults to null if not provided.
+#   referenced_security_group_id: The ID of the referenced security group to allow access from. Defaults to null if not provided.
+#   prefix_list_id: The ID of the prefix list to allow access from. Defaults to null if not provided.
+#   ip_protocol: The IP protocol to allow (e.g., "tcp", "udp", "icmp").
+#   from_port: The starting port to allow access from.
+#   to_port: The ending port to allow access to.
+#   description: A description for the ingress rule.
+#   tags: A map of tags to assign to the ingress rule. Includes a "Name" tag with the value from the ingress rule configuration.
+resource "aws_vpc_security_group_ingress_rule" "sg_ingress_rule" {
+  for_each                     = var.security-group-configuration["ingress"]
+  security_group_id            = var.security-group-configuration.name != null ? aws_security_group.security_group[0].id : var.security-group-configuration.security-group-id
+  cidr_ipv4                    = each.value["cidr-blocks"] != null ? each.value["cidr-blocks"] : null
+  referenced_security_group_id = each.value["referenced-sg-id"] != null ? each.value["referenced-sg-id"] : null
+  prefix_list_id               = each.value["prefix-list-id"] != null ? each.value["prefix-list-id"] : null
+  ip_protocol                  = each.value.protocol
+  from_port                    = each.value.from
+  to_port                      = each.value.to
+  description                  = each.value.description
+
+  tags = {
+    "Name" : each.value.name
+  }
+}
+
+
+# Creates an egress rule for a security group in AWS VPC.
+# 
+# Arguments:
+#   for_each: Iterates over the egress rules defined in the variable `security-group-configuration["egress"]`.
+#   security_group_id: The ID of the security group to which the egress rule will be applied. If the security group name is provided, it uses the ID of the created security group, otherwise it uses the provided security group ID.
+#   cidr_ipv4: The CIDR blocks to which the egress rule applies. Defaults to null if not provided.
+#   referenced_security_group_id: The ID of the referenced security group for the egress rule. Defaults to null if not provided.
+#   prefix_list_id: The ID of the prefix list for the egress rule. Defaults to null if not provided.
+#   ip_protocol: The IP protocol for the egress rule (e.g., "tcp", "udp", "icmp").
+#   from_port: The starting port for the egress rule.
+#   to_port: The ending port for the egress rule.
+#   description: A description for the egress rule.
+#   tags: A map of tags to assign to the egress rule, including a "Name" tag.
+resource "aws_vpc_security_group_egress_rule" "sg_egress_rule" {
+  for_each                     = var.security-group-configuration["egress"]
+  security_group_id            = var.security-group-configuration.name != null ? aws_security_group.security_group[0].id : var.security-group-configuration.security-group-id
+  cidr_ipv4                    = each.value["cidr-blocks"] != null ? each.value["cidr-blocks"] : null
+  referenced_security_group_id = each.value["referenced-sg-id"] != null ? each.value["referenced-sg-id"] : null
+  prefix_list_id               = each.value["prefix-list-id"] != null ? each.value["prefix-list-id"] : null
+  ip_protocol                  = each.value.protocol
+  from_port                    = each.value.from
+  to_port                      = each.value.to
+  description                  = each.value.description
+
+  tags = {
+    "Name" : each.value.name
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,45 @@
+/*
+####################################################################################################
+# Terraform Security Group Module Outputs Configuration
+#
+# Description: This module creates a Security Group in AWS with the specified rules.
+#
+# Author: Subhamay Bhattacharyya
+# Created: 29-Dec-2024 
+# Version: 1.0
+#
+####################################################################################################
+*/
+
+
+# This output provides the ID of the security group.
+# The ID can be used to reference the security group in other resources.
+output "security-group-id" {
+  description = "The ID of the security group."
+  value       = try(aws_security_group.security_group[0].id, "No security group ID.")
+}
+
+# This output provides the name of the security group.
+# The name can be used to identify the security group in the AWS console.
+output "security-group-name" {
+  description = "The ID of the security group."
+  value       = try(aws_security_group.security_group[0].name, "No security group name.")
+}
+
+# This output provides the ARN (Amazon Resource Name) of the security group.
+# The ARN is a unique identifier for the security group.
+output "security-group-arn" {
+  description = "The ARN of the security group."
+  value       = try(aws_security_group.security_group[0].arn, "No security group ARN.")
+}
+
+# This output provides the security group rules.
+# It includes both inbound and outbound rules.
+# If there are no rules, it will return a message indicating no rules are present.
+output "security-group-rules" {
+  description = "The security group rules."
+  value = {
+    inbound  = try(aws_vpc_security_group_egress_rule.sg_egress_rule.*, "No inbound rules."),
+    outbound = try(aws_vpc_security_group_ingress_rule.sg_ingress_rule.*, "No outbound rules.")
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,109 @@
+/*
+####################################################################################################
+# Terraform Security Group Module Variabls Configuration
+#
+# Description: This module creates a Security Group in AWS with the specified rules.
+#
+# Author: Subhamay Bhattacharyya
+# Created: 29-Dec-2024 
+# Version: 1.0
+#
+####################################################################################################
+*/
+
+######################################## Project Name ##############################################
+# This variable defines the name of the project.
+# It is a string type variable with a default value of "your-project-name".
+# You can override this default value by providing a different project name.
+variable "project-name" {
+  description = "The name of the project"
+  type        = string
+  default     = "your-project-name"
+}
+
+######################################## Security Group #########################################
+# This variable defines the VPC ID where the security group will be created.
+# - description: A brief explanation of the variable's purpose.
+# - type: The data type of the variable, which is a string in this case.
+# - default: The default value for the variable, which is an empty string.
+variable "vpc-id" {
+  description = "The VPC ID where the security group will be created."
+  type        = string
+  default     = ""
+}
+
+# 
+# This variable defines the configuration for the security group.
+# 
+# Variable: security-group-configuration
+# 
+# Description: Configuration for the security group.
+# 
+
+variable "security-group-configuration" {
+  description = "Configuration for the security group."
+  type = object({
+    name              = optional(string)
+    description       = optional(string)
+    security-group-id = optional(string)
+    ingress = map(object({
+      name             = string
+      description      = string
+      from             = number
+      to               = number
+      protocol         = string
+      cidr-blocks      = optional(string)
+      referenced-sg-id = optional(string)
+      prefix-list-id   = optional(string)
+    }))
+    egress = map(object({
+      name             = string
+      description      = string
+      from             = number
+      to               = number
+      protocol         = string
+      cidr-blocks      = optional(string)
+      referenced-sg-id = optional(string)
+      prefix-list-id   = optional(string)
+    }))
+  })
+  default = {
+    name        = "ec2-sg"
+    description = "EC2 Security Group"
+    ingress = {
+      ssh = {
+        name        = "Allows SSH"
+        description = "Allows outbound SSH traffic on port 22 to ec2 instance security group."
+        from        = 22
+        to          = 22
+        protocol    = "tcp"
+        cidr-blocks = "0.0.0.0/0"
+      }
+    }
+    egress = {
+    }
+  }
+}
+
+# This variable defines the ID of the security group to reference.
+# 
+# Type: string
+# Default: ""
+# 
+# Usage:
+# This variable should be set to the ID of an existing security group that you want to reference in your Terraform configuration.
+# variable "referenced-sg-id" {
+#   description = "The ID of the security group to reference."
+#   type        = string
+#   default     = ""
+# }
+
+######################################## GitHub ####################################################
+# The CI build string
+# This variable defines the CI build string.
+# It is a string type variable with a default value of an empty string.
+variable "ci-build" {
+  description = "The CI build string"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
### Initial Release of Terraform AWS Security Group Module

#### Added
- Initial release of the Terraform AWS Security Group module.
- Create security groups with or without specified ingress and egress rules.
- Add rules to an existing security group.
- Support for tagging resources.
- Example usage provided in README.
- Default tags configuration.

#### Files Added
- `.gitignore`: Updated to include Terraform, local environment, and IDE files.
- `CHANGELOG.md`: Added initial release notes.
- `LICENSE`: Added MIT License.
- `README.md`: Included detailed module usage, example configurations, and required inputs.
- `VERSION`: Recorded version 1.0.0 details.
- `data.tf`: Configured AWS region and caller identity data blocks.
- `main.tf`: Defined security group and rules creation logic.
- `outputs.tf`: Specified outputs for the security group module.
- `variables.tf`: Included variables for project name, VPC ID, and security group configuration.

For more details, please review the changes [here](https://github.com/subhamay-bhattacharyya/terraform-aws-security-group/compare/main...initial-release).